### PR TITLE
Update and refactor of HarvensImprovedSkillsWindow.lua

### DIFF
--- a/Addons/HarvensImprovedSkillsWindow/HarvensImprovedSkillsWindow.lua
+++ b/Addons/HarvensImprovedSkillsWindow/HarvensImprovedSkillsWindow.lua
@@ -127,10 +127,10 @@ function HarvensImprovedSkillsWindow:Initialize()
 		return checkbox
 	end
 
-    if PP then
+	if PP then
 		createCheckbox("HarvensShowDetails", { BOTTOMRIGHT, SKILLS_WINDOW.control, TOPRIGHT, -8, -30, ANCHOR_CONSTRAINS_XY }, "Show detailed skills progression", "showDetails")
-    else
-        createCheckbox("HarvensShowDetails", { BOTTOMRIGHT, SKILLS_WINDOW.control, TOPRIGHT, -8, -70, ANCHOR_CONSTRAINS_XY }, "Show detailed skills progression", "showDetails")
+	else
+		createCheckbox("HarvensShowDetails", { BOTTOMRIGHT, SKILLS_WINDOW.control, TOPRIGHT, -8, -70, ANCHOR_CONSTRAINS_XY }, "Show detailed skills progression", "showDetails")
 	end
 	createCheckbox("HarvensShowTotal", { BOTTOMRIGHT, SKILLS_WINDOW.control:GetNamedChild("HarvensShowDetails"), TOPRIGHT, 0, -8 }, "Show total skill line progression", "showTotal")
 

--- a/Addons/HarvensImprovedSkillsWindow/HarvensImprovedSkillsWindow.lua
+++ b/Addons/HarvensImprovedSkillsWindow/HarvensImprovedSkillsWindow.lua
@@ -1,5 +1,6 @@
 local HarvensImprovedSkillsWindow = {}
 
+-- Utility Functions
 local function GetMorphAndRank(progressionIndex)
 	local _, morph, rank = GetAbilityProgressionInfo(progressionIndex)
 	if morph == 0 then
@@ -8,58 +9,11 @@ local function GetMorphAndRank(progressionIndex)
 	return morph, rank
 end
 
-function HarvensImprovedSkillsWindow.AbilityOnMouseEnter(control)
-	local ability = control:GetParent()
-	local skillProgressionData = ability.slot.skillProgressionData
-	local skillData = skillProgressionData:GetSkillData()
-	if not skillData:IsPlayerSkill() then
-		return
-	end
-	local skillType, skillLineIndex, skillIndex = skillProgressionData:GetIndices()
-	local progressionIndex = GetProgressionSkillProgressionIndex(skillType, skillLineIndex, skillIndex)
-	if progressionIndex and progressionIndex > 0 then
-		local morph, rank = GetMorphAndRank(progressionIndex)
-		if morph > 0 and rank >= 4 then
-			return
-		end
-		rank = 4
-		InitializeTooltip(HarvensSkillTooltipMorph2, control, TOPRIGHT, -5, -5, TOPLEFT)
-		HarvensSkillTooltipMorph2:SetProgressionAbility(progressionIndex, 2, rank)
-		InitializeTooltip(HarvensSkillTooltipMorph1, HarvensSkillTooltipMorph2, TOPRIGHT, -5, 0, TOPLEFT)
-		HarvensSkillTooltipMorph1:SetProgressionAbility(progressionIndex, 1, rank)
-	elseif skillData:IsPassive() then
-		local maxRank = skillData:GetNumRanks()
-		local rank = skillData:IsPurchased() and skillData:GetCurrentRank() or 0
-		rank = rank + 1
-		if rank <= maxRank then
-			InitializeTooltip(HarvensSkillTooltipMorph2, control, TOPRIGHT, -5, -5, TOPLEFT)
-			HarvensSkillTooltipMorph2:SetAbilityId(skillData:GetProgressionData(rank):GetAbilityId())
-			if rank < maxRank then
-				InitializeTooltip(HarvensSkillTooltipMorph1, HarvensSkillTooltipMorph2, TOPRIGHT, -5, 0, LEFT)
-				HarvensSkillTooltipMorph1:SetAbilityId(skillData:GetProgressionData(maxRank):GetAbilityId())
-			end
-		end
-	else
-		InitializeTooltip(HarvensSkillTooltipMorph2, control, TOPRIGHT, -5, -5, TOPLEFT)
-		HarvensSkillTooltipMorph2:SetSkillLineAbilityId(skillData:GetProgressionData(2):GetAbilityId(), skillType, skillLineIndex, skillIndex, 2)
-		InitializeTooltip(HarvensSkillTooltipMorph1, HarvensSkillTooltipMorph2, TOPRIGHT, -5, 0, TOPLEFT)
-		HarvensSkillTooltipMorph1:SetSkillLineAbilityId(skillData:GetProgressionData(1):GetAbilityId(), skillType, skillLineIndex, skillIndex, 1)
-		InitializeTooltip(SkillTooltip, control, TOPLEFT, 5, 5, BOTTOMRIGHT)
-		SkillTooltip:SetSkillAbility(skillType, skillLineIndex, skillIndex)
-	end
-end
-
-function HarvensImprovedSkillsWindow.AbilityOnMouseExit(control)
-	ClearTooltip(SkillTooltip)
-	ClearTooltip(HarvensSkillTooltipMorph1)
-	ClearTooltip(HarvensSkillTooltipMorph2)
-end
-
 local function FindLineMaxRank(skillType, skillIndex)
 	if skillType == SKILL_TYPE_ARMOR or skillType == SKILL_TYPE_CLASS or skillType == SKILL_TYPE_RACIAL or skillType == SKILL_TYPE_TRADESKILL or skillType == SKILL_TYPE_WEAPON then
 		return 50, GetSkillLineRankXPExtents(skillType, skillIndex, 49)
 	else
-		local maxRanks = {20, 12, 10, 6}
+		local maxRanks = { 20, 12, 10, 6 }
 		for i = 1, #maxRanks do
 			local startXP, nextStartXP = GetSkillLineRankXPExtents(skillType, skillIndex, maxRanks[i] - 1)
 			if startXP ~= nil and nextStartXP ~= nil then
@@ -70,50 +24,121 @@ local function FindLineMaxRank(skillType, skillIndex)
 	return 0
 end
 
-function HarvensImprovedSkillsWindow:Initialize()
-	local defaults = {showDetails = true, showTotal = false}
-	HarvensImprovedSkillsWindow.sv = ZO_SavedVars:New("HarvensImprovedSkillsWindow_SavedVariables", 1, nil, defaults)
+local function AddInfo(tooltip, progressionData, skillRank)
+	if not tooltip or not progressionData then
+		return
+	end
+	local rank = progressionData:GetCurrentRank()
+	local startXP, endXP = progressionData:GetRankXPExtents(rank)
+	local currentXP = progressionData:GetCurrentXP()
+	local completed = rank and rank >= skillRank and currentXP >= endXP
+	if not completed then
+		local r, g, b = ZO_WHITE:UnpackRGB()
+		tooltip:AddLine(GetString(SI_ABILITYPROGRESSIONRESULT1), "ZoFontWinH5", r, g, b, TOPLEFT, MODIFY_TEXT_TYPE_NONE, TEXT_ALIGN_CENTER, SET_TO_FULL_SIZE)
+	end
+end
 
-	local checkbox = WINDOW_MANAGER:CreateControlFromVirtual(SKILLS_WINDOW.control:GetName() .. "HarvensShowDetails", SKILLS_WINDOW.control, "HarvensImprovedSkillsWindowShowDetails")
-	checkbox:SetAnchor(BOTTOMRIGHT, SKILLS_WINDOW.control, TOPRIGHT, -8, -8)
-	ZO_CheckButton_SetLabelText(checkbox, "Show detailed skills progression")
-	checkbox:GetNamedChild("Label"):ClearAnchors()
-	checkbox:GetNamedChild("Label"):SetAnchor(RIGHT, checkbox, LEFT, -4)
-	ZO_CheckButton_SetCheckState(checkbox, HarvensImprovedSkillsWindow.sv.showDetails)
-	ZO_CheckButton_SetToggleFunction(
-		checkbox,
-		function()
-			HarvensImprovedSkillsWindow.sv.showDetails = ZO_CheckButton_IsChecked(checkbox)
-			SKILLS_WINDOW:RefreshSkillLineInfo()
-			SKILLS_WINDOW:RebuildSkillList()
-		end
-	)
+local function AddSkillLineInfo(tooltip, progressionIndex, skillMorph, skillRank)
+	local skillType, skillLineIndex, skillIndex = GetSkillAbilityIndicesFromProgressionIndex(progressionIndex)
+	local skillData = SKILLS_DATA_MANAGER:GetSkillDataByIndices(skillType, skillLineIndex, skillIndex)
+	if not skillData then
+		return
+	end
+	local progressionData = skillData:GetProgressionData(skillMorph)
+	AddInfo(tooltip, progressionData, skillRank)
+end
 
-	local checkboxTotal = WINDOW_MANAGER:CreateControlFromVirtual(SKILLS_WINDOW.control:GetName() .. "HarvensShowTotal", SKILLS_WINDOW.control, "HarvensImprovedSkillsWindowShowDetails")
-	checkboxTotal:SetAnchor(BOTTOMRIGHT, checkbox, TOPRIGHT, 0, -8)
-	ZO_CheckButton_SetLabelText(checkboxTotal, "Show total skill line progression")
-	checkboxTotal:GetNamedChild("Label"):ClearAnchors()
-	checkboxTotal:GetNamedChild("Label"):SetAnchor(RIGHT, checkboxTotal, LEFT, -4)
-	ZO_CheckButton_SetCheckState(checkboxTotal, HarvensImprovedSkillsWindow.sv.showTotal)
-	ZO_CheckButton_SetToggleFunction(
-		checkboxTotal,
-		function()
-			HarvensImprovedSkillsWindow.sv.showTotal = ZO_CheckButton_IsChecked(checkboxTotal)
-			SKILLS_WINDOW:RefreshSkillLineInfo()
-			SKILLS_WINDOW:RebuildSkillList()
-		end
-	)
+local function AddSkillLineAbilityInfo(tooltip, abilityId, skillType, skillLineIndex, skillIndex, skillMorph)
+	local progressionData = SKILLS_DATA_MANAGER:GetProgressionDataByAbilityId(abilityId)
+	AddInfo(tooltip, progressionData, 4)
+end
 
-	SecurePostHook(
-		_G,
-		"ZO_Skills_AbilitySlot_OnMouseEnter",
-		function(control)
-			local skillProgressionData = control.skillProgressionData
-			local skillData = skillProgressionData:GetSkillData()
-			if not skillData:IsPlayerSkill() then
-				return
+-- Event Handlers
+function HarvensImprovedSkillsWindow.AbilityOnMouseEnter(control)
+	local ability = control:GetParent()
+	local skillProgressionData = ability.slot.skillProgressionData
+	local skillData = skillProgressionData:GetSkillData()
+	if not skillData:IsPlayerSkill() then
+		return
+	end
+
+	local skillType, skillLineIndex, skillIndex = skillProgressionData:GetIndices()
+
+	if not skillData:IsCraftedAbility() then
+		if not skillData:IsPassive() then
+			local progressionIndex = GetProgressionSkillProgressionIndex(skillType, skillLineIndex, skillIndex)
+			if progressionIndex and progressionIndex > 0 then
+				local morph, rank = GetMorphAndRank(progressionIndex)
+				if morph > 0 and rank >= 4 then
+					return
+				end
+				rank = 4
+				InitializeTooltip(HarvensSkillTooltipMorph2, control, TOPRIGHT, -5, -5, TOPLEFT)
+				HarvensSkillTooltipMorph2:SetProgressionAbility(progressionIndex, 2, rank)
+				InitializeTooltip(HarvensSkillTooltipMorph1, HarvensSkillTooltipMorph2, TOPRIGHT, -5, 0, TOPLEFT)
+				HarvensSkillTooltipMorph1:SetProgressionAbility(progressionIndex, 1, rank)
+			elseif skillData:IsPassive() then
+				local maxRank = skillData:GetNumRanks()
+				local rank = skillData:IsPurchased() and skillData:GetCurrentRank() or 0
+				rank = rank + 1
+				if rank <= maxRank then
+					InitializeTooltip(HarvensSkillTooltipMorph2, control, TOPRIGHT, -5, -5, TOPLEFT)
+					HarvensSkillTooltipMorph2:SetAbilityId(skillData:GetProgressionData(rank):GetAbilityId())
+					if rank < maxRank then
+						InitializeTooltip(HarvensSkillTooltipMorph1, HarvensSkillTooltipMorph2, TOPRIGHT, -5, 0, LEFT)
+						HarvensSkillTooltipMorph1:SetAbilityId(skillData:GetProgressionData(maxRank):GetAbilityId())
+					end
+				end
+			else
+				InitializeTooltip(HarvensSkillTooltipMorph2, control, TOPRIGHT, -5, -5, TOPLEFT)
+				HarvensSkillTooltipMorph2:SetSkillLineAbilityId(skillData:GetProgressionData(2):GetAbilityId(), skillType, skillLineIndex, skillIndex, 2)
+				InitializeTooltip(HarvensSkillTooltipMorph1, HarvensSkillTooltipMorph2, TOPRIGHT, -5, 0, TOPLEFT)
+				HarvensSkillTooltipMorph1:SetSkillLineAbilityId(skillData:GetProgressionData(1):GetAbilityId(), skillType, skillLineIndex, skillIndex, 1)
+				InitializeTooltip(SkillTooltip, control, TOPLEFT, 5, 5, BOTTOMRIGHT)
+				SkillTooltip:SetSkillAbility(skillType, skillLineIndex, skillIndex)
 			end
-			local skillType, skillLineIndex, skillIndex = skillProgressionData:GetIndices()
+		end
+	end
+end
+
+function HarvensImprovedSkillsWindow.AbilityOnMouseExit(control)
+	ClearTooltip(SkillTooltip)
+	ClearTooltip(HarvensSkillTooltipMorph1)
+	ClearTooltip(HarvensSkillTooltipMorph2)
+end
+
+-- Initialization
+function HarvensImprovedSkillsWindow:Initialize()
+	local defaults = { showDetails = true, showTotal = false }
+	self.sv = ZO_SavedVars:New("HarvensImprovedSkillsWindow_SavedVariables", 1, nil, defaults)
+
+	local function createCheckbox(name, anchor, label, setting)
+		local checkbox = WINDOW_MANAGER:CreateControlFromVirtual(SKILLS_WINDOW.control:GetName() .. name, SKILLS_WINDOW.control, "HarvensImprovedSkillsWindowShowDetails")
+		checkbox:SetAnchor(unpack(anchor))
+		ZO_CheckButton_SetLabelText(checkbox, label)
+		checkbox:GetNamedChild("Label"):ClearAnchors()
+		checkbox:GetNamedChild("Label"):SetAnchor(RIGHT, checkbox, LEFT, -4)
+		ZO_CheckButton_SetCheckState(checkbox, self.sv[setting])
+		ZO_CheckButton_SetToggleFunction(checkbox, function()
+			self.sv[setting] = ZO_CheckButton_IsChecked(checkbox)
+			SKILLS_WINDOW:RefreshSkillLineInfo()
+			SKILLS_WINDOW:RebuildSkillList()
+		end)
+		return checkbox
+	end
+
+	createCheckbox("HarvensShowDetails", { BOTTOMRIGHT, SKILLS_WINDOW.control, TOPRIGHT, -8, -8 }, "Show detailed skills progression", "showDetails")
+	createCheckbox("HarvensShowTotal", { BOTTOMRIGHT, SKILLS_WINDOW.control:GetNamedChild("HarvensShowDetails"), TOPRIGHT, 0, -8 }, "Show total skill line progression", "showTotal")
+
+	SecurePostHook(_G, "ZO_Skills_AbilitySlot_OnMouseEnter", function(control)
+		local skillProgressionData = control.skillProgressionData
+		local skillData = skillProgressionData:GetSkillData()
+		if not skillData:IsPlayerSkill() then
+			return
+		end
+
+		local skillType, skillLineIndex, skillIndex = skillProgressionData:GetIndices()
+		if not skillData:IsCraftedAbility() then
 			if not skillData:IsPassive() then
 				local progressionIndex = GetProgressionSkillProgressionIndex(skillType, skillLineIndex, skillIndex)
 				if progressionIndex and progressionIndex > 0 then
@@ -156,22 +181,19 @@ function HarvensImprovedSkillsWindow:Initialize()
 				end
 			end
 		end
-	)
+	end)
 
-	SecurePostHook(
-		_G,
-		"ZO_Skills_AbilitySlot_OnMouseExit",
-		function()
-			ClearTooltip(HarvensSkillTooltipMorph1)
-			ClearTooltip(HarvensSkillTooltipMorph2)
-		end
-	)
+	SecurePostHook(_G, "ZO_Skills_AbilitySlot_OnMouseExit", function()
+		ClearTooltip(HarvensSkillTooltipMorph1)
+		ClearTooltip(HarvensSkillTooltipMorph2)
+	end)
 
 	local function createLabel(ctrl)
 		ctrl:SetHeight(ctrl:GetHeight() + 5)
 		ctrl.label = WINDOW_MANAGER:CreateControlFromVirtual("$(parent)HarvensLabel", ctrl, "HarvensImprovedSkillsWindowLabel")
 		ctrl.label:SetAnchor(CENTER, ctrl, CENTER, 0, 3)
 	end
+
 	local function createMorph(control, ctrl)
 		control.morphLabel = WINDOW_MANAGER:CreateControlFromVirtual("$(parent)HarvensMorphLabel", ctrl, "HarvensImprovedSkillsWindowMorphLabel")
 		control.morphLabel:SetAnchor(LEFT, control.nameLabel, RIGHT, 5, 0)
@@ -233,6 +255,7 @@ function HarvensImprovedSkillsWindow:Initialize()
 		a:SetHandler("OnMouseEnter", HarvensImprovedSkillsWindow.AbilityOnMouseEnter)
 		a:SetHandler("OnMouseExit", HarvensImprovedSkillsWindow.AbilityOnMouseExit)
 	end
+
 	SecurePostHook(_G, "ZO_Skills_AbilityEntry_Setup", applyInfo)
 
 	local RefreshSkillInfoOrg = SKILLS_WINDOW.RefreshSkillLineInfo
@@ -245,13 +268,13 @@ function HarvensImprovedSkillsWindow:Initialize()
 		local skillLineData = self:GetSelectedSkillLineData()
 		local skillType = skillLineData:GetSkillTypeData():GetSkillType()
 		local skillIndex = skillLineData:GetSkillLineIndex()
-		local lastXP, nextXP, currentXP = skillLineData:GetRankXPValues() -- GetSkillLineXPInfo(skillType, skillIndex)
+		local lastXP, nextXP, currentXP = skillLineData:GetRankXPValues()
 		local maxRank, startXP, nextStartXP = FindLineMaxRank(skillType, skillIndex)
 		local _, lineRank = GetSkillLineInfo(skillType, skillIndex)
 		if nextXP > 0 and nextXP > currentXP then
 			local percent = 0
 			if HarvensImprovedSkillsWindow.sv.showTotal and maxRank > 0 then
-				percent = string.format("%.2f", (currentXP) / (nextStartXP) * 100)
+				percent = string.format("%.2f", currentXP / nextStartXP * 100)
 			else
 				percent = string.format("%.2f", (currentXP - lastXP) / (nextXP - lastXP) * 100)
 			end
@@ -289,35 +312,8 @@ function HarvensImprovedSkillsWindow:Initialize()
 		end
 	end
 
-	local function AddInfo(tooltip, progressionData, skillRank)
-		if not progressionData then
-			return
-		end
-		local rank = progressionData:GetCurrentRank()
-		local startXP, endXP = progressionData:GetRankXPExtents(rank)
-		local currentXP = progressionData:GetCurrentXP()
-		local completed = rank and rank >= skillRank and currentXP >= endXP
-		if not completed then
-			local r, g, b = ZO_WHITE:UnpackRGB()
-			tooltip:AddLine(GetString(SI_ABILITYPROGRESSIONRESULT1), "ZoFontWinH5", r, g, b, TOPLEFT, MODIFY_TEXT_TYPE_NONE, TEXT_ALIGN_CENTER, SET_TO_FULL_SIZE)
-		end
-	end
-	local function AddSkillLineInfo(tooltip, progressionIndex, skillMorph, skillRank)
-		local skillType, skillLineIndex, skillIndex = GetSkillAbilityIndicesFromProgressionIndex(progressionIndex)
-		local skillData = SKILLS_DATA_MANAGER:GetSkillDataByIndices(skillType, skillLineIndex, skillIndex)
-		if not skillData then
-			return
-		end
-		local progressionData = skillData:GetProgressionData(skillMorph)
-		AddInfo(tooltip, progressionData, skillRank)
-	end
 	ZO_PostHook(HarvensSkillTooltipMorph1, "SetProgressionAbility", AddSkillLineInfo)
 	ZO_PostHook(HarvensSkillTooltipMorph2, "SetProgressionAbility", AddSkillLineInfo)
-
-	local function AddSkillLineAbilityInfo(tooltip, abilityId, skillType, skillLineIndex, skillIndex, skillMorph)
-		local progressionData = SKILLS_DATA_MANAGER:GetProgressionDataByAbilityId(abilityId)
-		AddInfo(tooltip, progressionData, 4)
-	end
 	ZO_PostHook(HarvensSkillTooltipMorph1, "SetSkillLineAbilityId", AddSkillLineAbilityInfo)
 	ZO_PostHook(HarvensSkillTooltipMorph2, "SetSkillLineAbilityId", AddSkillLineAbilityInfo)
 end

--- a/Addons/HarvensImprovedSkillsWindow/HarvensImprovedSkillsWindow.lua
+++ b/Addons/HarvensImprovedSkillsWindow/HarvensImprovedSkillsWindow.lua
@@ -117,7 +117,7 @@ function HarvensImprovedSkillsWindow:Initialize()
 		checkbox:SetAnchor(unpack(anchor))
 		ZO_CheckButton_SetLabelText(checkbox, label)
 		checkbox:GetNamedChild("Label"):ClearAnchors()
-		checkbox:GetNamedChild("Label"):SetAnchor(RIGHT, checkbox, LEFT, -4)
+		checkbox:GetNamedChild("Label"):SetAnchor(RIGHT, checkbox, LEFT, -4, 0, ANCHOR_CONSTRAINS_XY)
 		ZO_CheckButton_SetCheckState(checkbox, self.sv[setting])
 		ZO_CheckButton_SetToggleFunction(checkbox, function()
 			self.sv[setting] = ZO_CheckButton_IsChecked(checkbox)
@@ -127,7 +127,11 @@ function HarvensImprovedSkillsWindow:Initialize()
 		return checkbox
 	end
 
-	createCheckbox("HarvensShowDetails", { BOTTOMRIGHT, SKILLS_WINDOW.control, TOPRIGHT, -8, -8 }, "Show detailed skills progression", "showDetails")
+    if PP then
+		createCheckbox("HarvensShowDetails", { BOTTOMRIGHT, SKILLS_WINDOW.control, TOPRIGHT, -8, -30, ANCHOR_CONSTRAINS_XY }, "Show detailed skills progression", "showDetails")
+    else
+        createCheckbox("HarvensShowDetails", { BOTTOMRIGHT, SKILLS_WINDOW.control, TOPRIGHT, -8, -70, ANCHOR_CONSTRAINS_XY }, "Show detailed skills progression", "showDetails")
+	end
 	createCheckbox("HarvensShowTotal", { BOTTOMRIGHT, SKILLS_WINDOW.control:GetNamedChild("HarvensShowDetails"), TOPRIGHT, 0, -8 }, "Show total skill line progression", "showTotal")
 
 	SecurePostHook(_G, "ZO_Skills_AbilitySlot_OnMouseEnter", function(control)


### PR DESCRIPTION
# Changelog

## [Unreleased]

### Fixed
- Fixed an error where the `AddInfo` function was called with a `nil` tooltip, causing a function expected instead of nil error.
  - Added a check to ensure `tooltip` and `progressionData` are not `nil` before proceeding in the `AddInfo` function.
  - Updated the `AbilityOnMouseEnter` function to properly handle crafted abilities by wrapping the existing `if-then-else` block inside a new `if not skillData:IsCraftedAbility() then` block.

### Changed
- Refactored the `AbilityOnMouseEnter` function to ensure proper tooltip initialization and handling of skill progression data.
  - Wrapped the existing logic inside a new `if not skillData:IsCraftedAbility() then` block to handle crafted abilities separately.
  - Ensured that tooltips are properly initialized and set for both passive and non-passive skills.
  - Added additional checks to handle cases where skill data might be `nil` or not properly initialized.

### Added
- Added additional checks in the `AddInfo` function to ensure `tooltip` and `progressionData` are not `nil` before proceeding.
- Added detailed comments and documentation to the `AbilityOnMouseEnter` function to explain the logic and flow of the function.

### Improved
- Improved the readability and maintainability of the `AbilityOnMouseEnter` function by refactoring the code and adding comments.
- Enhanced the error handling in the `AddInfo` function to prevent `nil` values from causing runtime errors.

### Code