### PR TITLE
LibAsync Version: 2.3.5

### DIFF
--- a/Addons/LibAsync/LibAsync.txt
+++ b/Addons/LibAsync/LibAsync.txt
@@ -1,12 +1,12 @@
 ## Title: LibAsync
 ## Author: votan
-## APIVersion: 100034 100035
-## AddOnVersion: 20304
-## Version: 2.3.4
+## APIVersion: 101043 101044
+## AddOnVersion: 20305
+## Version: 2.3.5
 ## IsLibrary: true
 ## Description: A share scheduler for deferred actions
 ## OptionalDependsOn: LibDebugLogger
 
-## This Add-On is not created by, affiliated with or sponsored by ZeniMax Media Inc. or its affiliates. The Elder Scrolls® and related logos are registered trademarks or trademarks of ZeniMax Media Inc. in the United States and/or other countries. All rights reserved.
+## This Add-On is not created by, affiliated with or sponsored by ZeniMax Media Inc. or its affiliates. The Elder ScrollsÂ® and related logos are registered trademarks or trademarks of ZeniMax Media Inc. in the United States and/or other countries. All rights reserved.
 
 LibAsync.lua


### PR DESCRIPTION
# Default Threshold Table (Before Changes)

| Threshold                | Frame Time (s) | FPS Equivalent | Hard Coded |
|--------------------------|-----------------|----------------|------------|
| Vsync (frameTimeTarget)   | 0.01400         | 71.43          | X (default value)          |
| MinFrameTime             | 0.01250         | 80.00          |            |
| spendTimeDef             | 0.00938         | 106.61         |            |
| spendTimeDefNoHUD        | 0.01500         | 66.67          | X          |
| Initial spendTime        | 0.00938         | 106.61         |            |
| CPU Load > spendTime     | 0.03000         | 33.33          | X          |

# Default SpendTime Adjustment Table (Before Changes)

| Scenario           | spendTimeDef / FPS | spendTimeDefNoHUD / FPS | Adjustment Factor | Percentage |
|--------------------|-------------------------|----------------------------|-------------------|------------|
| Not Running        | 0.00938 / 106.61 FPS    | 0.01500 / 66.67 FPS         | 0.005             | 0.5%       |
| CPU Load > spendTime| 0.03000 / 33.33 FPS     | 0.03000 / 33.33 FPS         | 0.02              | 2%         |
| No Jobs            | 0.00938 / 106.61 FPS    | 0.01500 / 66.67 FPS         | 0.5               | 50%        |

# SpendTimeDef Comparison Table for MinFrameTime Values (After Update)

| FPS | MinFrameTime | upperSpendTimeDef | upperSpendTimeDefNoHUD | lowerSpendTimeDef | lowerSpendTimeDefNoHUD |
|----------------|-------------|-------------------|------------------------|------------------|-----------------------|
| 50 FPS | 0.02000000 | 0.01411 (14.11ms) / FPS 70.85 | 0.01714 (17.14ms) / FPS 58.34 | 0.05999 (59.99ms) / FPS 16.67 | 0.04799 (47.99ms) / FPS 20.84 |
| 60 FPS | 0.01666667 | 0.01176 (11.76ms) / FPS 85.02 | 0.01428 (14.28ms) / FPS 70.01 | 0.04999 (49.99ms) / FPS 20.0 | 0.03999 (39.99ms) / FPS 25.0 |
| 70 FPS | 0.01428571 | 0.01008 (10.08ms) / FPS 99.19 | 0.01224 (12.24ms) / FPS 81.68 | 0.04285 (42.85ms) / FPS 23.34 | 0.03428 (34.28ms) / FPS 29.17 |
| 96 FPS | 0.01041667 | 0.00735 (7.35ms) / FPS 136.03 | 0.00893 (8.93ms) / FPS 112.02 | 0.03124 (31.24ms) / FPS 32.01 | 0.02500 (25.0ms) / FPS 40.01 |
| 100 FPS | 0.01000000 | 0.00706 (7.06ms) / FPS 141.7 | 0.00857 (8.57ms) / FPS 116.69 | 0.02999 (29.99ms) / FPS 33.34 | 0.02400 (24.0ms) / FPS 41.68 |
| 120 FPS | 0.00833333 | 0.00588 (5.88ms) / FPS 170.03 | 0.00714 (7.14ms) / FPS 140.03 | 0.02499 (24.99ms) / FPS 40.01 | 0.02000 (20.0ms) / FPS 50.01 |
| 144 FPS | 0.00694444 | 0.00490 (4.9ms) / FPS 204.04 | 0.00595 (5.95ms) / FPS 168.03 | 0.02083 (20.83ms) / FPS 48.01 | 0.01666 (16.66ms) / FPS 60.01 |

# Current Behavior

Currently with the hard coded values for someone on a laptop or other PC with windows 10 but with performance specs similar to mine are restricted by hard coded values. When the CPU Load exceeds the time allowed to process a job or when the HUD or UI is closed the values are above the FPS equivalent of what the FPS might be for a player in a city by a bank in Vvardenfell for example.

I was testing how I could run each task sequentially for MM and because two routines Purge Duplicates and a Refresh of the cache use LibAsync I tried them while in Vvardenfell. Sometimes I'm just playing the game and test something and then feel that works so I upload a different version of MM. Not knowing the impact of things going on in the background.

With the current version of LibAsync trying to purge duplicates for 70,000 sales by a bank takes 500 seconds and the highest was 1508 seconds. If I'm in the Saint Delyn Penthouse it takes **1 second**. 

That was such a drastic change I had to investigate why. Initially I noticed that while printing debug messages the spendTime and cpuLoad were sometimes drastically different. One time it even seemed to simply halt and after 20 minutes I used `d("hello")` and it appeared instantly but LibAsync had sat there doing nothing for over 20 minutes. When I used tbug I could see the tasks for the jobs if I could have looked at the local variables and seen whether or not `running` was true I could have been more sure. Since LibAsync has an idle state and isn't ever really finished then I doubt it had simply stopped.

# Changes

The changes make it so that someone with a 60 FPS limit would have better results. If someone were to edit `UserSettings.txt` they could change MinFrameTime.2 to something else and everything will scale.

There is an added feature for when you are ALT tabbed out and ESO is in the background to limit the FPS. I don't think it affects the runtime of the game but ZOS didn't answer my question as to how it works exactly. If a user enables that feature then they can use the in game slider to set the FPS and then reload the UI for the changes to take affect. It doesn't require adding a LAM menu doing it that way. Because nobody is telling me what it really does my assumption that it only affects things when ESO is not in the foreground then I don't see it impacting game play.

