### PR TITLE
Version: 3.0.2

### DIFF
--- a/Addons/LibAsync/LibAsync.lua
+++ b/Addons/LibAsync/LibAsync.lua
@@ -18,20 +18,21 @@ local Warn = async.Warn
 local log_to_chat = false
 
 -- Main Constants
-local VSYNC_FRAME_TIME_MS = 0.01667 -- 60 fps
+local UPPER_FPS_BOUND = 60.1
+local ASYNC_DEFAULT_STALL_THRESHOLD = 15
+local ASYNC_STALL_THRESHOLD = ASYNC_DEFAULT_STALL_THRESHOLD
+local ASYNC_MIN_STALL_THRESHOLD = 15
+local CPU_ADJUSTMENT_RATE = 0.03
+local IDLE_UI_ADJUSTMENT_FACTOR = 0.8335
+local IDLE_NO_UI_ADJUSTMENT_FACTOR = 1.0
+local THROTTLE_UI_ADJUSTMENT_FACTOR = 0.75
+local THROTTLE_NO_UI_ADJUSTMENT_FACTOR = 1.0
+
+-- Constants for CPU measurement
 local MIN_DELAY_FOR_ASYNC = 10 -- minimum ms before using async delay
 local INIT_DELAY_MS = 50 -- delay for initialization
-local CPU_DECREASE_RATE = 0.005 -- 0.5% decrease per frame when not running
-local CPU_INCREASE_RATE = 0.02 -- 2% increase per frame when overloaded
-
--- Scheduler Operation Constants
-local SCHEDULER_THROTTLE_RATE = 0.5 -- Rate to throttle scheduler when time threshold reached
-local DEBUG_FREEZE_THRESHOLD_MS = 0.016 -- Threshold in ms before considering a frame freeze
+local DEBUG_FREEZE_THRESHOLD = 0.01667
 local DEBUG_TIME_MULTIPLIER = 1000 -- Multiplier to convert time to milliseconds for debug output
-
--- Scene State Constants
-local SCENE_SHOWN = ZO_STATE.SHOWN
-local SCENE_HIDING = ZO_STATE.HIDING
 
 local em = GetEventManager()
 local remove = table.remove
@@ -113,124 +114,114 @@ local function DoJob(job)
   current, call = nil, nil
 end
 
+-- Create local variables from AsyncSavedVars
+do
+	-- Initialize AsyncSavedVars if not already defined
+	AsyncSavedVars = AsyncSavedVars or {}
+
+	-- Use ASYNC_DEFAULT_STALL_THRESHOLD if ASYNC_STALL_THRESHOLD is not defined
+	AsyncSavedVars.ASYNC_STALL_THRESHOLD = AsyncSavedVars.ASYNC_STALL_THRESHOLD or ASYNC_DEFAULT_STALL_THRESHOLD
+
+	-- Create local variable from AsyncSavedVars
+	ASYNC_STALL_THRESHOLD = AsyncSavedVars.ASYNC_STALL_THRESHOLD
+end
+
 local debug = false
 local running
-local GetFrameTimeSeconds, GetGameTimeSeconds = GetFrameTimeSeconds, GetGameTimeSeconds
--- VSYNC Value (based on a 60Hz monitor refresh rate)
-local vsyncValue = GetCVar("VSYNC") == "1" and VSYNC_FRAME_TIME_MS or nil
 
--- MinFrameTime.2 Setting
-local minFrameTimeValue = tonumber(GetCVar("MinFrameTime.2"))
-minFrameTimeValue = (minFrameTimeValue and minFrameTimeValue > 0.0001) and minFrameTimeValue or nil
+-- return to upperFrameTimeTarget when no jobs are in the callstack
+local upperFrameTimeTarget = 1.0 / UPPER_FPS_BOUND
+local spendTime = upperFrameTimeTarget
 
--- Final frameTimeTarget Calculation
-local frameTimeTarget = vsyncValue or minFrameTimeValue or VSYNC_FRAME_TIME_MS
-
-local upperSpendTimeDef = frameTimeTarget * 0.995 --A bit higher than target framerate
-local upperSpendTimeDefNoHUD = upperSpendTimeDef
-local lowerSpendTimeDef = upperSpendTimeDef * 2 -- Half of target framerate
-local lowerSpendTimeDefNoHUD = lowerSpendTimeDef * 1.21429
-
---- @return number
-local function GetUpperThreshold()
-  return (HUD_SCENE:IsShowing() or HUD_UI_SCENE:IsShowing()) and upperSpendTimeDef or upperSpendTimeDefNoHUD
-end
-
---- @return number
-local function GetLowerThreshold()
-  return (HUD_SCENE:IsShowing() or HUD_UI_SCENE:IsShowing()) and lowerSpendTimeDef or lowerSpendTimeDefNoHUD
-end
-local spendTime = GetUpperThreshold()
 local job = nil
 local cpuLoad = 0
-local lowpass1 = frameTimeTarget
-local function returnToTargetFramerate()
-  local upperLimit = GetUpperThreshold()
-  spendTime = max(upperLimit, spendTime - spendTime * CPU_DECREASE_RATE)
-
-  local currentFrameTime = 1.0 / GetFramerate()
-  --Learn capability of the machine by getting an average framerate
-  lowpass1 = lowpass1 * 0.995 + 0.005 * currentFrameTime
-  upperSpendTimeDef = lowpass1 * 0.98 --A bit higher than target framerate => try to reach the cap
-  upperSpendTimeDefNoHUD = upperSpendTimeDef * 1.21429
-  lowerSpendTimeDef = upperSpendTimeDef * 2 -- Half of target framerate
-  lowerSpendTimeDefNoHUD = lowerSpendTimeDef * 1.21429
-end
-local function needMoreTime()
-  local currentFrameTime = 1.0 / GetFramerate()
-  spendTime = min(GetLowerThreshold(), spendTime + currentFrameTime * CPU_INCREASE_RATE)
-end
-
 function async.Scheduler()
-  --InfoBarFormRepair:SetText(1.0 / spendTime)
-  if not running then
-    returnToTargetFramerate()
-    return
-  end
+	local currentFrameRate = GetFramerate()
+	local lowerFrameRate = zo_max(ASYNC_STALL_THRESHOLD, zo_floor(currentFrameRate * 0.25))
+	local lowerFrameTimeTarget = (1 / lowerFrameRate)
 
-  job = nil
-  local name = nil
-  local runTime
-  local start, now = GetFrameTimeSeconds(), GetGameTimeSeconds()
-  async.frameTimeSeconds = start
-  runTime, cpuLoad = start, now - start
-  if cpuLoad > spendTime then
-    needMoreTime()
-    if debug then
-      Debug(format("initial gap: %.3fms CPU time. skip. new threshold: %.3fms", cpuLoad * DEBUG_TIME_MULTIPLIER, spendTime * DEBUG_TIME_MULTIPLIER))
-    end
-    return
-  end
-  -- oncePerFrame
-  while (now - start) <= spendTime do
-    name, job = next(jobs, name)
-    if job then
-      runTime = now
-      DoJob(job)
-      now = GetGameTimeSeconds()
-    else
-      break
-    end
-  end
-  if (now - start) <= (spendTime - 0.001) then -- Worth starting?
-    -- loops
-    local allOnlyOnce = true
-    while (now - start) <= spendTime do
-      name, job = next(jobs, name)
-      if not job then
-        if allOnlyOnce then
-          -- Could leave earlier
-          returnToTargetFramerate()
-          break
-        end
-        name, job = next(jobs)
-        allOnlyOnce = true
-      end
-      if job then
-        if not job.oncePerFrame then
-          allOnlyOnce = false
-          runTime = now
-          DoJob(job)
-          now = GetGameTimeSeconds()
-        end
-      else
-        running = next(jobs) ~= nil
-        -- Could leave earlier
-        returnToTargetFramerate()
-        break
-      end
-    end
-  else
-    needMoreTime()
-  end
-  if debug and job then
-    local freezeTime = now - start
-    if freezeTime >= DEBUG_FREEZE_THRESHOLD_MS then
-      -- Add debug output to verify values
-      local msg = format("%s freeze. allowed: %.3fms, used %.3fms starting at %.3fms, resulting fps %i.", job.name, spendTime * DEBUG_TIME_MULTIPLIER, (now - runTime) * DEBUG_TIME_MULTIPLIER, (runTime - start) * DEBUG_TIME_MULTIPLIER, 1 / freezeTime)
-      Warn(msg) -- Use pre-formatted string
-    end
-  end
+	--InfoBarFormRepair:SetText(1 / spendTime)
+	if not running then
+		local hudUiAdjustmentFactor = (not HUD_SCENE:IsShowing() and not HUD_UI_SCENE:IsShowing()) and IDLE_UI_ADJUSTMENT_FACTOR or IDLE_NO_UI_ADJUSTMENT_FACTOR
+		spendTime = zo_max(upperFrameTimeTarget, spendTime - spendTime * CPU_ADJUSTMENT_RATE)
+		return
+	end
+
+	job = nil
+	local name = nil
+	local runTime
+	local start, now = GetFrameTimeSeconds(), GetGameTimeSeconds()
+	async.frameTimeSeconds = start
+	runTime, cpuLoad = start, now - start
+
+	if cpuLoad > spendTime then
+		-- Gradually increase spendTime while capping it based on lowerFrameTimeTarget.
+		local hudUiAdjustmentFactor = (not HUD_SCENE:IsShowing() and not HUD_UI_SCENE:IsShowing()) and THROTTLE_UI_ADJUSTMENT_FACTOR or THROTTLE_NO_UI_ADJUSTMENT_FACTOR
+		spendTime = zo_min(lowerFrameTimeTarget * hudUiAdjustmentFactor, spendTime + spendTime * CPU_ADJUSTMENT_RATE)
+		if debug then
+			Debug("[LibAsync - spendtime Adjustment ] lowerFrameTimeTarget: %.3f, initial gap: %.3f, new threshold: %.3f", lowerFrameTimeTarget, (GetGameTimeSeconds() - start), spendTime)
+		end
+		return
+	end
+
+	-- oncePerFrame
+	while (now - start) <= spendTime do
+		name, job = next(jobs, name)
+		if job then
+			runTime = now
+			DoJob(job)
+			now = GetGameTimeSeconds()
+		else
+			break
+		end
+	end
+
+	-- Process additional jobs if there is remaining time
+	if (now - start) <= spendTime then
+		-- loops
+		local allOnlyOnce = true
+		while (now - start) <= spendTime do
+			name, job = next(jobs, name)
+			if not job then
+				if allOnlyOnce then
+					break
+				end
+				name, job = next(jobs)
+				allOnlyOnce = true
+			end
+			if job then
+				if not job.oncePerFrame then
+					allOnlyOnce = false
+					runTime = now
+					DoJob(job)
+					now = GetGameTimeSeconds()
+				end
+			else
+				running = next(jobs) ~= nil
+				-- Do not adjust spendTime abruptly
+				-- 'spendTime will return to upperFrameTimeTarget when 'not running'
+				return
+			end
+		end
+	end
+
+	if debug and job then
+		local freezeTime = now - start
+		local hudUiAdjustmentFactor = (not HUD_SCENE:IsShowing() and not HUD_UI_SCENE:IsShowing()) and THROTTLE_UI_ADJUSTMENT_FACTOR or THROTTLE_NO_UI_ADJUSTMENT_FACTOR
+		if freezeTime >= DEBUG_FREEZE_THRESHOLD then
+			Warn("[LibAsync] %s freeze. allowed: '%.5f: %.0fms', used %.3fms starting at %.3fms, resulting fps %.3f, currentFrameRate: %.5f, lowerFrameRate: %.5f, lowerFrameTimeTarget: '%.5f: %.0fms', upperFrameTimeTarget: '%.5f: %.0fms'.",
+				job.name,
+				spendTime, spendTime * 1000,
+				(now - runTime) * 1000,
+				(runTime - start) * 1000,
+				(1 / freezeTime),
+				currentFrameRate,
+				lowerFrameRate,
+				(lowerFrameTimeTarget * hudUiAdjustmentFactor), (lowerFrameTimeTarget * hudUiAdjustmentFactor) * DEBUG_TIME_MULTIPLIER,
+				upperFrameTimeTarget, upperFrameTimeTarget * DEBUG_TIME_MULTIPLIER
+			)
+		end
+	end
 end
 
 --- @return boolean
@@ -245,7 +236,7 @@ end
 
 --- @return number
 function async:GetCpuLoad()
-  return cpuLoad / frameTimeTarget
+	return cpuLoad / upperFrameTimeTarget
 end
 
 --- Enable or disable logging to chat
@@ -628,6 +619,70 @@ end
 -- To break a for-loop, return async.BREAK
 async.BREAK = true
 
+function async.Slash(...)
+	local num_args = select("#", ...)
+	local allArgs = ""
+
+	-- Concatenate arguments into a single string
+	if num_args > 0 then
+		for i = 1, num_args do
+			local value = select(i, ...)
+			if type(value) == "string" then
+				allArgs = allArgs .. " " .. value
+			elseif type(value) == "number" then
+				allArgs = allArgs .. " " .. tostring(value)
+			end
+		end
+		allArgs = zo_strtrim(allArgs)
+	end
+
+	local args, argValue = "", nil
+	for w in zo_strgmatch(allArgs, "%w+") do
+		if args == "" then
+			args = w
+		else
+			argValue = tonumber(w) or zo_strlower(w)
+		end
+	end
+
+	args = zo_strlower(args)
+
+	if args == "stall" then
+		if type(argValue) == "number" then
+			-- Validate the FPS number
+			if argValue < ASYNC_MIN_STALL_THRESHOLD then
+				d(string.format("[LibAsync] Invalid FPS value. The stall threshold must be at least %d FPS. Use /async stall <number>.", ASYNC_MIN_STALL_THRESHOLD))
+				return
+			elseif argValue > UPPER_FPS_BOUND then
+				d(string.format("[LibAsync] Invalid FPS value. The stall threshold must be no greater than %d FPS. Use /async stall <number>.", UPPER_FPS_BOUND))
+				return
+			end
+
+			-- Clamp and apply the value
+			local adjustedFps = zo_min(UPPER_FPS_BOUND, zo_max(ASYNC_MIN_STALL_THRESHOLD, argValue))
+			AsyncSavedVars.ASYNC_STALL_THRESHOLD = adjustedFps
+			ASYNC_STALL_THRESHOLD = AsyncSavedVars.ASYNC_STALL_THRESHOLD
+
+			-- Notify the user of the updated stall threshold
+			d(string.format("[LibAsync] Stall threshold set to %d FPS.", adjustedFps))
+
+		elseif type(argValue) == "string" and argValue == "default" then
+			-- Set to the default stall threshold
+			AsyncSavedVars.ASYNC_STALL_THRESHOLD = ASYNC_DEFAULT_STALL_THRESHOLD
+			ASYNC_STALL_THRESHOLD = AsyncSavedVars.ASYNC_STALL_THRESHOLD
+
+			-- Notify the user of the reset to default
+			d(string.format("[LibAsync] Stall threshold reset to the default value of %d FPS.", ASYNC_DEFAULT_STALL_THRESHOLD))
+		else
+			-- Invalid argument
+			d("[LibAsync] Invalid argument. Use /async stall <number> or /async stall default.")
+		end
+	else
+		-- Unknown command
+		d("[LibAsync] Unknown command. Use /async stall <number> or /async stall default.")
+	end
+end
+
 -- Scheduler Management
 local SchedulerManager = {
   schedulerId = nil,
@@ -671,32 +726,6 @@ function SchedulerManager:initialize(delay)
   )
 end
 
--- Scene Management
-local SceneManager = {
-  scenes = {HUD_SCENE, HUD_UI_SCENE}
-}
-
-function SceneManager:handleStateChange(_, newState)
-  if newState == SCENE_SHOWNING then
-    --end
-    --if not running then
-    spendTime = GetUpperThreshold()
-  elseif newState == SCENE_HIDING then
-    -- Increase time, if not higher already
-    spendTime = max(spendTime, upperSpendTimeDefNoHUD)
-  end
-end
-
-function SceneManager:initialize()
-  local stateCallback = function(...)
-    self:handleStateChange(...)
-  end
-
-  for _, scene in ipairs(self.scenes) do
-    scene:RegisterCallback("StateChange", stateCallback)
-  end
-end
-
 do
   local identifier = "ASYNCTASKS_JOBS"
 
@@ -708,9 +737,7 @@ do
       SchedulerManager:initialize()
     end
   )
-
-  SceneManager:initialize()
-
+  SLASH_COMMANDS['/async'] = function(...) async:Slash(...) end
   SchedulerManager:startScheduler()
 end
 

--- a/Addons/LibAsync/LibAsync.txt
+++ b/Addons/LibAsync/LibAsync.txt
@@ -1,9 +1,10 @@
 ## Title: LibAsync
 ## Author: votan
 ## APIVersion: 101044 101045
-## AddOnVersion: 30001
-## Version: 3.0.1
+## AddOnVersion: 30020
+## Version: 3.0.2
 ## IsLibrary: true
+## SavedVariables: AsyncSavedVars
 ## Description: A share scheduler for deferred actions
 ## OptionalDependsOn: LibDebugLogger
 


### PR DESCRIPTION
Sorry didn't mean to close Version: 3.0.1, the rebase did it automatically.

As mentioned in #38 this adjusts to the players current FPS eliminating the need to read settings, have a state change when opening the UI outside the scheduler, and abruptly altering spandTime. When the UI is open or closed that still affects LibAsync.

Hopefully some people try the test version and provide some feedback.