### PR TITLE
LibHarvensAddonSettings - Remove sort from dropdown control creation

### DIFF
--- a/Addons/LibHarvensAddonSettings/Console/Settings.lua
+++ b/Addons/LibHarvensAddonSettings/Console/Settings.lua
@@ -212,12 +212,6 @@ local createControlFunctions = {
 		LibHarvensAddonSettings.list:AddEntry(Templates[self.type], self)
 	end,
 	[LibHarvensAddonSettings.ST_DROPDOWN] = function(self, lastControl)
-		table.sort(
-			self.items,
-			function(leftData, rightData)
-				return leftData.name < rightData.name
-			end
-		)
 		LibHarvensAddonSettings.list:AddEntry(Templates[self.type], self)
 	end,
 	[LibHarvensAddonSettings.ST_LABEL] = function(self, lastControl)


### PR DESCRIPTION
Reasoning: 
The `table.sort` requires `items` to be a table, preventing us from passing an updater function instead.
This could be fixed by simply checking if it's a table or passing through `GetValueOrCallback` first, but `items` is not necessarily desired to be sorted in the first place. 
This also only exists for Console, so removing make sit more consistent with PC.