### PR TITLE
Resolve conflict with addons that have extended settings

### DIFF
--- a/Addons/has2lam/has2lam.lua
+++ b/Addons/has2lam/has2lam.lua
@@ -102,15 +102,24 @@ local function HookLibHarvensAddonSettings()
 		)
 	end
 
-	local function RefreshPanel(panel)
-		local addonSettings = panel and panel.addonSettings
-		if addonSettings and addonSettings.Select then
-			if not addonSettings.selected then
-				addonSettings:Select()
-			end
-			LibHarvensAddonSettings:RefreshAddonSettings()
-		end
-	end
+    local function RefreshPanel(panel)
+        local addonSettings = panel and panel.addonSettings
+        if addonSettings and addonSettings.Select and LibHarvensAddonSettings.addons then
+            local isLibHarvensAddon = false
+            for i = 1, #LibHarvensAddonSettings.addons do
+                if LibHarvensAddonSettings.addons[i] == addonSettings then
+                    isLibHarvensAddon = true
+                    break
+                end
+            end
+            if isLibHarvensAddon then
+                if not addonSettings.selected then
+                    addonSettings:Select()
+                end
+                LibHarvensAddonSettings:RefreshAddonSettings()
+            end
+        end
+    end
 
 	function LibHarvensAddonSettings:CreateAddonList()
 		local prev = nil

--- a/Addons/has2lam/has2lam.txt
+++ b/Addons/has2lam/has2lam.txt
@@ -1,13 +1,13 @@
 ; This Add-on is not created by, affiliated with or sponsored by ZeniMax
-; Media Inc. or its affiliates. The Elder Scrolls® and related logos are
+; Media Inc. or its affiliates. The Elder ScrollsÂ® and related logos are
 ; registered trademarks or trademarks of ZeniMax Media Inc. in the United
 ; States and/or other countries. All rights reserved.
 
 ## Title: Harven's AS to LAM adapter
 ## Description: This addon is an adapter which will convert Harven's Addons Settings layout to LAM settings layout.
-## APIVersion: 101040 101041
-## Version: 2.2.9
+## APIVersion: 101048 101049
+## Version: 2.3.0
 ## Author: Harven & votan
-## DependsOn: LibHarvensAddonSettings>=10901 LibAddonMenu-2.0>=35
+## DependsOn: LibHarvensAddonSettings>=20101 LibAddonMenu-2.0>=41
 
 has2lam.lua


### PR DESCRIPTION
<img width="1417" height="638" alt="image" src="https://github.com/user-attachments/assets/3e7db71e-66e1-4ad7-a4b4-b7d23ee6f106" />


https://www.esoui.com/downloads/fileinfo.php?s=ace2ed87719731d0e29faa3df9cf901c&id=2311#comments

With the change to the RefreshPanel function has2lam now functions correctly,

<img width="1266" height="934" alt="image" src="https://github.com/user-attachments/assets/8d523f71-31f8-439c-863d-fd6573e4c34b" />
