### PR TITLE
added ability to set ignoreDefault

### DIFF
--- a/Addons/LibHarvensAddonSettings/Console/Settings.lua
+++ b/Addons/LibHarvensAddonSettings/Console/Settings.lua
@@ -268,6 +268,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 		self.canSelect = params.canSelect
 	end,
@@ -282,6 +283,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end,
 	[LibHarvensAddonSettings.ST_BUTTON] = function(self, params)
@@ -289,6 +291,7 @@ local setupControlFunctions = {
 		self.labelText = params.label
 		self.tooltipText = params.tooltip
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 		self.buttonText = params.buttonText
 	end,
@@ -300,6 +303,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end,
 	[LibHarvensAddonSettings.ST_DROPDOWN] = function(self, params)
@@ -309,6 +313,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end,
 	[LibHarvensAddonSettings.ST_LABEL] = function(self, params)
@@ -326,6 +331,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end,
 	[LibHarvensAddonSettings.ST_ICONPICKER] = function(self, params)
@@ -335,6 +341,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end
 }

--- a/Addons/LibHarvensAddonSettings/LibHarvensAddonSettings.addon
+++ b/Addons/LibHarvensAddonSettings/LibHarvensAddonSettings.addon
@@ -5,8 +5,8 @@
 
 ## Title: LibHarvensAddonSettings
 ## Author: Harven, Votan
-## AddOnVersion: 20101
-## Version: 2.1.1
+## AddOnVersion: 20102
+## Version: 2.1.2
 ## APIVersion: 101047 101048
 ## IsLibrary: true
 ## Description: With this addon you can create and add your addon settings to the common settings page. The settings page can be found in Settings->Addons menu.

--- a/Addons/LibHarvensAddonSettings/Main.lua
+++ b/Addons/LibHarvensAddonSettings/Main.lua
@@ -100,6 +100,7 @@ function AddonSettingsControl:SetValue(...)
 end
 
 function AddonSettingsControl:ResetToDefaults()
+	if self.ignoreDefault then return end
 	if self.type == LibHarvensAddonSettings.ST_DROPDOWN then
 		self:SetValue(self.default)
 		if self.control then

--- a/Addons/LibHarvensAddonSettings/PC/Settings.lua
+++ b/Addons/LibHarvensAddonSettings/PC/Settings.lua
@@ -356,6 +356,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end,
 	[LibHarvensAddonSettings.ST_SLIDER] = function(self, params)
@@ -369,6 +370,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end,
 	[LibHarvensAddonSettings.ST_BUTTON] = function(self, params)
@@ -376,6 +378,7 @@ local setupControlFunctions = {
 		self.labelText = params.label
 		self.tooltipText = params.tooltip
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 		self.buttonText = params.buttonText
 	end,
@@ -387,6 +390,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end,
 	[LibHarvensAddonSettings.ST_DROPDOWN] = function(self, params)
@@ -396,6 +400,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end,
 	[LibHarvensAddonSettings.ST_LABEL] = function(self, params)
@@ -412,6 +417,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end,
 	[LibHarvensAddonSettings.ST_ICONPICKER] = function(self, params)
@@ -421,6 +427,7 @@ local setupControlFunctions = {
 		self.setFunction = params.setFunction
 		self.getFunction = params.getFunction
 		self.default = params.default
+		self.ignoreDefault = params.ignoreDefault
 		self.disable = params.disable
 	end
 }


### PR DESCRIPTION
this adds the option to define if you want to ignore the ResetToDefaults() call.
example of use is a setting that handles character or Account wide saveVars, if you set default to be character and you want to reset Account wide to default, you have to put the setting right at the bottom of your settings menu so it gets called last and dosn't change what save your reseting.

Sory about this being so short 1st time ever doing this pull request stuff.
