### PR TITLE
Dynamic Add / Removal accounts for sections.

### DIFF
--- a/Addons/LibHarvensAddonSettings/Console/Settings.lua
+++ b/Addons/LibHarvensAddonSettings/Console/Settings.lua
@@ -446,6 +446,37 @@ function LibHarvensAddonSettings.AddonSettings:RefreshSelection()
 	end
 end
 
+function LibHarvensAddonSettings.AddonSettings:SetupSections()
+	local settings = self.settings
+	-- local hasSections = false
+	-- for i = 1, #settings do
+	-- 	if settings[i].type == LibHarvensAddonSettings.ST_SECTION then
+	-- 		hasSections = true
+	-- 		break
+	-- 	end
+	-- end
+	-- if hasSections then
+	-- 	if settings[1].type ~= LibHarvensAddonSettings.ST_SECTION and settings[1].type ~= LibHarvensAddonSettings.ST_LABEL then
+	-- 		addonSettings:AddSetting({type = LibHarvensAddonSettings.ST_SECTION, label = GetString(SI_GAMEPLAY_OPTIONS_GENERAL)}, 1, false)
+	-- 	end
+	-- else
+	-- 	return
+	-- end
+
+	local currentSection = nil
+	for i = 1, #settings do
+		local setting = settings[i]
+		local isSection = setting.type == LibHarvensAddonSettings.ST_SECTION
+		if isSection then
+			currentSection = nil
+		end
+		setting.currentSection = currentSection
+		if isSection then
+			currentSection = setting
+		end
+	end
+end
+
 ----- end -----
 
 function LibHarvensAddonSettings:RefreshAddonSettings()
@@ -794,43 +825,12 @@ function LibHarvensAddonSettings:CreateAddonSettingsPanel()
 	self.list = self.scrollList:GetMainList()
 	self.scrollList:AddList("Section")
 
-	local function SetupSections(addonSettings)
-		local settings = addonSettings.settings
-		-- local hasSections = false
-		-- for i = 1, #settings do
-		-- 	if settings[i].type == LibHarvensAddonSettings.ST_SECTION then
-		-- 		hasSections = true
-		-- 		break
-		-- 	end
-		-- end
-		-- if hasSections then
-		-- 	if settings[1].type ~= LibHarvensAddonSettings.ST_SECTION and settings[1].type ~= LibHarvensAddonSettings.ST_LABEL then
-		-- 		addonSettings:AddSetting({type = LibHarvensAddonSettings.ST_SECTION, label = GetString(SI_GAMEPLAY_OPTIONS_GENERAL)}, 1, false)
-		-- 	end
-		-- else
-		-- 	return
-		-- end
-
-		local currentSection = nil
-		for i = 1, #settings do
-			local setting = settings[i]
-			local isSection = setting.type == LibHarvensAddonSettings.ST_SECTION
-			if isSection then
-				currentSection = nil
-			end
-			setting.currentSection = currentSection
-			if isSection then
-				currentSection = setting
-			end
-		end
-	end
-
 	CALLBACK_MANAGER:RegisterCallback(
 		"LibHarvensAddonSettings_AddonSelected",
 		function(_, addonSettings)
 			currentSettings = addonSettings
 			self.list.currentSection = nil
-			SetupSections(addonSettings)
+			addonSettings:SetupSections()
 			self.scrollList:SetCurrentList(self.scrollList:GetMainList())
 			addonSettings:CreateControls()
 		end

--- a/Addons/LibHarvensAddonSettings/Main.lua
+++ b/Addons/LibHarvensAddonSettings/Main.lua
@@ -176,6 +176,11 @@ function AddonSettings:AddSetting(params, index, playAnimation)
 	table.insert(self.settings, index, setting)
 	setting:SetupControl(params)
 
+	--Put insertions into proper sections.
+	if ZO_IsConsoleOrGameCoreUI() then
+		self:SetupSections()
+	end
+
 	--Force the settings page to update immediately if currently showing.
 	--The cleanup earlier prevents duplicate controls from being created.
 	if self.selected then
@@ -223,6 +228,12 @@ function AddonSettings:RemoveSettings(index, count, playAnimation)
 		if not self.settings[index] then break end
 		table.insert(removedSettingsList, table.remove(self.settings, index))
 	end
+
+	--Fix sections
+	if ZO_IsConsoleOrGameCoreUI() then
+		self:SetupSections()
+	end
+
 	--Force immediate page update
 	if self.selected then
 		self:CreateControls()


### PR DESCRIPTION
If you have a dynamic page that adds or removes settings after the first initialization, the updated settings list will now correctly account for sections.